### PR TITLE
Add the discord to the website Fixes #24

### DIFF
--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -61,6 +61,14 @@ export default function Navbar({ currentPage = "home" }: NavbarProps) {
             >
               GitHub
             </a>
+            <a
+              href="https://discord.gg/649Q4HG3XK"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-700 hover:text-blue-600 font-medium transition-colors"
+            >
+              Discord
+            </a>
           </nav>
 
           {/* Mobile menu button */}
@@ -150,6 +158,14 @@ export default function Navbar({ currentPage = "home" }: NavbarProps) {
                 >
                   GitHub
                 </a>
+                <a
+              href="https://discord.gg/649Q4HG3XK"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-700 hover:text-blue-600 font-medium transition-colors"
+            >
+              Discord
+            </a>
               </nav>
             </div>
           </div>

--- a/apps/web/pages/contributors.tsx
+++ b/apps/web/pages/contributors.tsx
@@ -115,6 +115,14 @@ export default function Contributors() {
                 >
                   License
                 </a>
+                 <a
+          href="https://discord.gg/649Q4HG3XK"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-gray-500 hover:text-gray-700"
+        >
+          Discord
+        </a>
               </div>
             </div>
           </div>

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -320,6 +320,14 @@ export default function Home() {
                 >
                   License
                 </a>
+                 <a
+          href="https://discord.gg/649Q4HG3XK"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-gray-500 hover:text-gray-700"
+        >
+          Discord
+        </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Pull Request

## Description
Added a persistent Discord link in both Navbar and Footer, so it is visible on every page.

Navbar now shows Discord along with GitHub on all pages.
Footer now contains Contributing | License | Discord links consistently.


<img width="1917" height="929" alt="Screenshot 2025-10-02 170002" src="https://github.com/user-attachments/assets/cf5aef3b-28ef-4d6b-839a-1ad8a3789367" />



