### PR TITLE
feat(website): add client-side tag filtering to components list

### DIFF
--- a/apps/web/components/TagChip.tsx
+++ b/apps/web/components/TagChip.tsx
@@ -3,7 +3,7 @@ import React from "react"
 interface TagChipProps {
   tag: string
   active: boolean
-  onToggle: (tag: string) => void
+  onToggle: (_tag: string) => void
 }
 
 /**
@@ -11,7 +11,8 @@ interface TagChipProps {
  * - Uses aria-pressed to indicate toggle state
  * - Keeps visual focus outline for keyboard users
  */
-export function TagChip({ tag, active, onToggle }: TagChipProps) {
+export function TagChip(props: TagChipProps) {
+  const { tag, active, onToggle } = props
   return (
     <button
       type="button"

--- a/apps/web/components/TagChip.tsx
+++ b/apps/web/components/TagChip.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+
+interface TagChipProps {
+  tag: string
+  active: boolean
+  onToggle: (tag: string) => void
+}
+
+/**
+ * Accessible tag chip button used for filtering.
+ * - Uses aria-pressed to indicate toggle state
+ * - Keeps visual focus outline for keyboard users
+ */
+export function TagChip({ tag, active, onToggle }: TagChipProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={() => onToggle(tag)}
+      className={`px-2 py-1 rounded-full text-xs font-medium border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 focus-visible:ring-offset-white ${
+        active
+          ? "bg-blue-100 border-blue-200 text-blue-700"
+          : "bg-gray-100 border-gray-200 text-gray-700 hover:bg-gray-200"
+      }`}
+    >
+      {tag}
+    </button>
+  )
+}
+
+export default TagChip


### PR DESCRIPTION
# Pull Request

## Description
Adds client‑side tag filtering to the components listing page [index.tsx]. A new “Tags” panel in the left sidebar lets users toggle one or more tags (OR semantics) to refine the list in combination with existing search and category filters. Selected tags appear beneath the header with quick remove (×) actions and a Clear button. Includes a reusable [TagChip] component [TagChip.tsx] with accessible focus styles.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New component (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Checklist
- [X] My code follows the code style of this project
- [X] I have included a screenshot or demo of the component
- [X] I have verified the component metadata follows the schema
- [X] All validation checks pass (`pnpm validate`)
- [X] I have tested the component in different screen sizes (if applicable)

## Screenshots
<img width="1357" height="924" alt="image" src="https://github.com/user-attachments/assets/44deb692-c788-4374-b57e-56f3a9e815a6" />


## Additional Notes
This is an official contrubution for Hacktoberfest'25

## Resolves: #62 
