### PR TITLE
Add word-wrap toggle button for components' code blocks

### DIFF
--- a/apps/web/pages/component/[...path].tsx
+++ b/apps/web/pages/component/[...path].tsx
@@ -571,9 +571,10 @@ export default function ComponentPage() {
                             </span>
                           </div>
                           <div className="px-6 py-4 bg-gray-50 dark:bg-gray-800">
-                            <pre className={`text-sm text-gray-800 dark:text-gray-100 overflow-x-auto ${wordWrap ? 'whitespace-pre-wrap' : 'whitespace-pre'}`}>
-                              <code>{content}</code>
-                            </pre>
+<pre className={`text-sm text-gray-800 dark:text-gray-100 overflow-x-auto ${wordWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}>
+  <code>{content}</code>
+</pre>
+
                           </div>
                           {index <
                             Object.entries(component.files).length - 1 && (


### PR DESCRIPTION
This PR solves issue #87  : adds a word-wrap toggle button beside the copy-to-clipboard icon in the components' code blocks.
- Allows users to toggle line wrapping for better readability.
- Keeps the existing design and structure intact.

### Screenshots:
#### Before Clicking the Button
When word wrap is **off**, long lines scroll horizontally.
![word wrap off](https://res.cloudinary.com/dxallozr5/image/upload/v1759688860/before_wrap_phgzab.png)

####  After Clicking the Button
When word wrap is **on**, long lines automatically wrap within the code block.
![word wrap on](https://res.cloudinary.com/dxallozr5/image/upload/v1759688900/after_wrap_mdrdbw.png)
