### PR TITLE
Fix(preview): Vue previews not working [#96]

### DIFF
--- a/components/section/vue/accordion/Accordion.vue
+++ b/components/section/vue/accordion/Accordion.vue
@@ -2,11 +2,7 @@
   <div
     class="w-full border border-gray-200 dark:border-gray-700 rounded-2xl divide-y divide-gray-200 dark:divide-gray-700"
   >
-    <div
-      v-for="(item, index) in items"
-      :key="index"
-      class="group"
-    >
+    <div v-for="(item, index) in items" :key="index" class="group">
       <!-- Header -->
       <button
         @click="toggle(index)"
@@ -16,13 +12,17 @@
         <svg
           :class="[
             'w-5 h-5 transform transition-transform duration-300',
-            openIndex === index ? 'rotate-180' : 'rotate-0'
+            openIndex === index ? 'rotate-180' : 'rotate-0',
           ]"
           stroke="currentColor"
           stroke-width="2"
           viewBox="0 0 24 24"
         >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M19 9l-7 7-7-7"
+          />
         </svg>
       </button>
 
@@ -40,7 +40,7 @@
           class="overflow-hidden px-5 pb-4 text-gray-600 dark:text-gray-300"
         >
           <!-- Slot or default content -->
-          <slot :name="`content-${index}`">{{ item.content }}</slot>
+          <slot :name="'content-' + index">{{ item.content }}</slot>
         </div>
       </transition>
     </div>
@@ -48,7 +48,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from "vue";
+import { ref, watch } from "vue"
 
 const props = defineProps({
   /**
@@ -57,11 +57,19 @@ const props = defineProps({
    */
   items: {
     type: Array,
-    required: true,
     default: () => [
-      { title: "What is Vue.js?", content: "Vue.js is a progressive framework for building UIs." },
-      { title: "What is TailwindCSS?", content: "TailwindCSS is a utility-first CSS framework." },
-      { title: "Why use both?", content: "Because they're fast, flexible, and fun!" },
+      {
+        title: "What is Vue.js?",
+        content: "Vue.js is a progressive framework for building UIs.",
+      },
+      {
+        title: "What is TailwindCSS?",
+        content: "TailwindCSS is a utility-first CSS framework.",
+      },
+      {
+        title: "Why use both?",
+        content: "Because they're fast, flexible, and fun!",
+      },
     ],
   },
   /**
@@ -78,27 +86,38 @@ const props = defineProps({
     type: [Number, Array],
     default: () => [],
   },
-});
+})
 
-const openIndex = ref(null);
-const openIndexes = ref([]); // for multiple mode
+const openIndex = ref(null)
+const openIndexes = ref([]) // for multiple mode
 
 watch(
   () => props.defaultOpen,
-  (val) => {
-    if (props.multiple) openIndexes.value = Array.isArray(val) ? val : [val];
-    else openIndex.value = Array.isArray(val) ? val[0] : val;
+  val => {
+    if (props.multiple) openIndexes.value = Array.isArray(val) ? val : [val]
+    else openIndex.value = Array.isArray(val) ? val[0] : val
   },
   { immediate: true }
-);
+)
 
 function toggle(index) {
   if (props.multiple) {
     if (openIndexes.value.includes(index))
-      openIndexes.value = openIndexes.value.filter((i) => i !== index);
-    else openIndexes.value.push(index);
+      openIndexes.value = openIndexes.value.filter(i => i !== index)
+    else openIndexes.value.push(index)
   } else {
-    openIndex.value = openIndex.value === index ? null : index;
+    openIndex.value = openIndex.value === index ? null : index
   }
+}
+
+const Preview = {
+  props: ["items", "multiple", "defaultOpen"],
+  setup() {
+    return {
+      items: props.items,
+      multiple: props.multiple,
+      defaultOpen: props.defaultOpen,
+    }
+  },
 }
 </script>


### PR DESCRIPTION
# Pull Request

## Description
A way to recognize vue files was implemented in the preview of [...path].tsx, and a way to display the component through iframe was created.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New component (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Component Details (if applicable)
- **Component Name**: Accordion
- **Category**: Component
- **Framework**: vue

## Checklist
- [x] My code follows the code style of this project
- [x] I have included a screenshot or demo of the component
- [ ] I have added/updated appropriate documentation (README.md)
- [ ] I have verified the component metadata follows the schema
- [x] All validation checks pass (`pnpm validate`)
- [x] The component includes proper MIT license attribution
- [x] I have tested the component in different screen sizes (if applicable)

## Screenshots
<img width="1268" height="351" alt="Captura de tela 2025-10-06 104809" src="https://github.com/user-attachments/assets/0d842809-f29e-49d7-983e-9ebc1c6e1b84" />
<img width="1309" height="367" alt="Captura de tela 2025-10-06 105829" src="https://github.com/user-attachments/assets/52c65e99-dbab-4068-8e67-e4ae5872233e" />

## Additional Notes
There are several points to consider that I was unable to test because I only have one Vue component, but the main one is how to pass props dynamically, because the iframe does not handle Vue's defineProps, which makes it very difficult, opening up possibilities for this solution to be only temporary since I had to pass the props directly into the iframe, which makes it static, and thus it would be unfeasible to do this for each Vue component, which would require creating a new preview for each new component that would make the [.. .path].tsx code very large.   
