### PR TITLE
fix:Tech Navbar Icon Not Displaying in preview

### DIFF
--- a/components/navbar/react/tech-navbar/TechNabar.jsx
+++ b/components/navbar/react/tech-navbar/TechNabar.jsx
@@ -2,17 +2,16 @@ import React from "react"
 import { FaSpaceShuttle } from "react-icons/fa"
 
 const defaultProps = {
-  logo: <FaSpaceShuttle />,
   navItems: ["Work", "About", "Playground", "Resource"],
   email: "ihyaet@gmail.com",
 }
 
-export default function TechNavbar({ logo, navItems, email }) {
+export default function TechNavbar({ navItems = defaultProps.navItems, email = defaultProps.email }) {
   return (
-    <nav className="bg-gray-900 rounded-full px-8 py-4 flex items-center justify-between shadow-xl max-w-4xl mx-auto mt-8">
+    <nav className="flex items-center justify-between px-8 py-4 mx-auto mt-8 max-w-4xl bg-gray-900 rounded-full shadow-xl">
       {/* Logo */}
       <div className="flex items-center justify-center w-12 h-12 bg-white rounded-full">
-        <span className="text-2xl">{logo}</span>
+        <FaSpaceShuttle className="text-2xl text-gray-900" />
       </div>
 
       {/* Navigation Items */}
@@ -21,7 +20,7 @@ export default function TechNavbar({ logo, navItems, email }) {
           <a
             key={index}
             href={`#${item.toLowerCase()}`}
-            className="text-white text-lg font-medium hover:text-gray-300 transition-colors"
+            className="text-white text-lg font-medium transition-colors hover:text-gray-300"
           >
             {item}
           </a>
@@ -29,7 +28,7 @@ export default function TechNavbar({ logo, navItems, email }) {
       </div>
 
       {/* Email */}
-      <div className="bg-white rounded-full px-6 py-2">
+      <div className="px-6 py-2 bg-white rounded-full">
         <span className="text-gray-900 text-lg font-medium">{email}</span>
       </div>
     </nav>


### PR DESCRIPTION
# Pull Request

Fixes : #135 

## Description
The original implementation passed the <FaSpaceShuttle /> JSX element through [defaultProps](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as a prop, which caused rendering issues in the ReactPreview system. The preview system couldn't properly handle JSX elements passed through object literals in defaultProps.

Solution : Instead of passing the icon as a prop, render it directly in the component JSX

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New component (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update



## Checklist
- [x] My code follows the code style of this project
- [x] I have included a screenshot or demo of the component
- [x] I have added/updated appropriate documentation (README.md)
- [x] I have verified the component metadata follows the schema
- [x] All validation checks pass (`pnpm validate`)
- [x] The component includes proper MIT license attribution
- [x] I have tested the component in different screen sizes (if applicable)

## Screenshots
Please include screenshots or a demo of your component:
<img width="1705" height="1002" alt="Screenshot from 2025-10-09 21-47-18" src="https://github.com/user-attachments/assets/8e8e6731-caff-4992-ae07-05092d83b012" />




