### PR TITLE
feat: add HoverToExpand Button component for React

### DIFF
--- a/components/button/react/HoverToExpand-Button/HoverButton.jsx
+++ b/components/button/react/HoverToExpand-Button/HoverButton.jsx
@@ -1,0 +1,39 @@
+
+import React from "react"
+
+/**
+ * HoverButton UI Component
+ * @param {Object} props
+ * @param {string} props.text - Content inside the button
+ * @param {string} [props.className] - Additional Tailwind classes
+ */
+const HoverButton = ({ text = "Hover me", className = "" }) => {
+  return (
+    <div>
+      <button className={`group relative inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-neutral-950 font-medium text-neutral-200 transition-all duration-300 hover:w-32 ${className}`}>
+        <div className="inline-flex whitespace-nowrap opacity-0 transition-all duration-200 group-hover:-translate-x-3 group-hover:opacity-100">
+          {text}
+        </div>
+        <div className="absolute right-3.5">
+          <svg
+            width="15"
+            height="15"
+            viewBox="0 0 15 15"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+          >
+            <path
+              d="M8.14645 3.14645C8.34171 2.95118 8.65829 2.95118 8.85355 3.14645L12.8536 7.14645C13.0488 7.34171 13.0488 7.65829 12.8536 7.85355L8.85355 11.8536C8.65829 12.0488 8.34171 12.0488 8.14645 11.8536C7.95118 11.6583 7.95118 11.3417 8.14645 11.1464L11.2929 8H2.5C2.22386 8 2 7.77614 2 7.5C2 7.22386 2.22386 7 2.5 7H11.2929L8.14645 3.85355C7.95118 3.65829 7.95118 3.34171 8.14645 3.14645Z"
+              fill="currentColor"
+              fillRule="evenodd"
+              clipRule="evenodd"
+            ></path>
+          </svg>
+        </div>
+      </button>
+    </div>
+  )
+}
+
+export default HoverButton

--- a/components/button/react/HoverToExpand-Button/README.md
+++ b/components/button/react/HoverToExpand-Button/README.md
@@ -1,0 +1,57 @@
+# Hover To Expand Button (React)
+
+A compact, circular action button that smoothly expands in width on hover to reveal a text label, with an arrow icon. Built with React and Tailwind CSS.
+
+Source: `components/button/react/HoverToExpand-Button/HoverButton.jsx`
+
+## Features
+- **Compact by default**: Renders as a 48px circular button.
+- **Smooth expansion**: Expands to show the label text on hover.
+- **Clean transitions**: Uses Tailwind `transition` utilities for both width and text reveal.
+- **Icon included**: Right-aligned arrow SVG with `currentColor`.
+- **Easy customization**: Extend with `className` to tweak size, colors, and effects.
+
+## Usage
+```jsx
+import React from "react";
+import HoverButton from "./HoverButton"; // adjust path as needed
+
+export default function Demo() {
+  return (
+    <div className="p-6 flex gap-4">
+      <HoverButton text="Explore" />
+      <HoverButton text="Read more" className="bg-indigo-600 text-white" />
+    </div>
+  );
+}
+```
+
+## Props
+- **text** (string, default: `"Hover me"`)
+  Label text that becomes visible when the button expands.
+
+- **className** (string, default: `""`)
+  Additional Tailwind CSS classes to override styling (size, colors, etc.).
+
+## Customization
+- **Size**: Override `h-12 w-12 hover:w-32` via `className`.
+  ```jsx
+  <HoverButton text="Start" className="h-10 w-10 hover:w-28" />
+  ```
+- **Colors**: Change background and text colors.
+  ```jsx
+  <HoverButton text="Docs" className="bg-emerald-600 text-emerald-50" />
+  ```
+- **Rounded/shape**: Modify `rounded-full` by supplying your own rounding class.
+  ```jsx
+  <HoverButton text="Go" className="rounded-lg" />
+  ```
+
+## Accessibility
+- The text label is present in the DOM even when visually hidden, so it serves as an accessible name for screen readers.
+- The arrow SVG is decorative. If needed, you can treat it as decorative by adding `aria-hidden="true"` via a small refactor; otherwise it inherits `currentColor` and has no explicit title.
+- Consider adding focus styles via `className` (e.g., `focus:outline-none focus:ring-2 focus:ring-offset-2`) to improve keyboard visibility.
+
+## Notes
+- Requires Tailwind CSS utilities (e.g., `group`, `transition`, `duration-*`, etc.).
+- Works out of the box with React 18+.

--- a/components/button/react/HoverToExpand-Button/component.json
+++ b/components/button/react/HoverToExpand-Button/component.json
@@ -1,0 +1,28 @@
+{
+  "name": "hover-to-expand-button",
+  "category": "button",
+  "framework": "react",
+  "tags": ["button", "hover", "animation", "tailwindcss", "expand", "ui"],
+  "author": "harshchill",
+  "license": "MIT",
+  "version": "1.0.0",
+  "preview": "Circular button that expands on hover to reveal text with a sliding animation and arrow icon.",
+  "demoUrl": "",
+  "props": [
+    {
+      "name": "text",
+      "type": "string",
+      "required": false,
+      "default": "Hover me",
+      "description": "Label text revealed when the button expands on hover."
+    },
+    {
+      "name": "className",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Additional Tailwind CSS utility classes to customize the button."
+    }
+  ],
+  "dependencies": ["react", "tailwindcss"]
+ }


### PR DESCRIPTION
# Pull Request

## Description
A compact, circular action button that smoothly expands in width on hover to reveal a text label, with an arrow icon. Built with React and Tailwind CSS

fixes #143 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New component (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Component Details (if applicable)
- **Component Name**:  HoverToExpand Button
- **Category**: Button
- **Framework**: React

## Checklist
- [x] My code follows the code style of this project
- [x] I have included a screenshot or demo of the component
- [x] I have added/updated appropriate documentation (README.md)
- [x] I have verified the component metadata follows the schema
- [x] All validation checks pass (`pnpm validate`)
- [x] The component includes proper MIT license attribution
- [x] I have tested the component in different screen sizes (if applicable)

## Screenshots
Please include screenshots or a demo of your component:
<img width="274" height="196" alt="Screenshot 2025-10-10 133843" src="https://github.com/user-attachments/assets/0baf3a96-3ca2-4edc-a395-9ceb1217c26f" />

## Additional Notes
Add any other context about the pull request here.
