### PR TITLE
feat: add avatar-group-label component

### DIFF
--- a/components/badge/react/avatar-group-label/README.md
+++ b/components/badge/react/avatar-group-label/README.md
@@ -1,0 +1,34 @@
+# Avatar Group Label
+
+A compact avatar group with overlapping profile pictures and a trust label — great for showing credibility or user engagement.
+
+**Author:** [@shridmishra](https://github.com/shridmishra)
+
+---
+
+## Features
+
+- Displays multiple circular avatars in an overlapping row.
+- Includes a customizable trust label.
+- Fully styled with Tailwind CSS.
+- Lightweight and framework-agnostic.
+
+---
+
+## Props
+
+| Prop       | Type      | Default                   | Description                                      |
+| :---------- | :-------- | :------------------------ | :----------------------------------------------- |
+| `avatars`   | string[]  | `[]`                      | Array of image URLs for avatars.                 |
+| `label`     | string    | `"Trusted by 10,000+ people"` | Text displayed next to the avatar group.         |
+
+---
+
+## Usage
+
+```jsx
+import AvatarGroupLabel from "./AvatarGroupLabel"
+
+export default function App() {
+  return <AvatarGroupLabel />
+}

--- a/components/badge/react/avatar-group-label/avatar-group-label.jsx
+++ b/components/badge/react/avatar-group-label/avatar-group-label.jsx
@@ -1,0 +1,24 @@
+export default function AvatarGroupLabel() {
+    return (
+        <div className="flex flex-wrap items-center justify-center p-1 rounded-full bg-gray-900 border border-gray-700 text-sm w-[300px] mx-auto">
+            <div className="flex items-center">
+                <img
+                    className="w-[30px] rounded-full border-2 border-gray-900"
+                    src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?q=80&w=50"
+                    alt="userImage1"
+                />
+                <img
+                    className="w-[30px] rounded-full border-2 border-gray-900 -translate-x-2"
+                    src="https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?q=80&w=50"
+                    alt="userImage2"
+                />
+                <img
+                    className="w-[30px] rounded-full border-2 border-gray-900 -translate-x-4"
+                    src="https://images.unsplash.com/photo-1438761681033-6461ffad8d80?q=80&w=50&h=50&auto=format&fit=crop"
+                    alt="userImage3"
+                />
+            </div>
+            <p className="-translate-x-2 text-gray-300">Trusted by 10,000+ people</p>
+        </div>
+    );
+}

--- a/components/badge/react/avatar-group-label/component.json
+++ b/components/badge/react/avatar-group-label/component.json
@@ -1,0 +1,23 @@
+{
+  "name": "avatar-group-label",
+  "category": "badge",
+  "framework": "react",
+  "tags": ["avatar", "profile", "group", "trust", "label"],
+  "author": "shridmishra",
+  "license": "MIT",
+  "version": "1.0.0",
+  "preview": "An avatar group with overlapping profile pictures and a trust label.",
+  "props": [
+    {
+      "name": "avatars",
+      "type": "string[]",
+      "description": "Array of image URLs to display as avatars."
+    },
+    {
+      "name": "label",
+      "type": "string",
+      "description": "Text displayed next to the avatar group.",
+      "default": "Trusted by 10,000+ people"
+    }
+  ]
+}


### PR DESCRIPTION
# Pull Request

## Description
Added a reusable Avatar Group Label component for React with Tailwind CSS. Displays a group of overlapping avatars with a label, compatible with dark themes and fixed width.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New component (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Component Details (if applicable)
- **Component Name**: avatar-group-label
- **Category**: badge
- **Framework**: React, TailwindCSS

## Checklist
- [x] My code follows the code style of this project
- [x] I have included a screenshot or demo of the component
- [x] I have added/updated appropriate documentation (README.md)
- [x] I have verified the component metadata follows the schema
- [x] All validation checks pass (`pnpm validate`)
- [x] The component includes proper MIT license attribution
- [x] I have tested the component in different screen sizes (if applicable)

## Screenshots
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/a5453d36-9de4-4b13-8c99-21bc3c359705" />

## Additional Notes

### Component Structure

components/avatar/react/avatar-group-label/
├── component.json       # Component metadata
├── AvatarGroupLabel.jsx # Main component
└── README.md            # Documentation
