### PR TITLE
feat: add reusable modal component for React

### DIFF
--- a/components/modal/react/modal/Modal.jsx
+++ b/components/modal/react/modal/Modal.jsx
@@ -1,0 +1,237 @@
+import React, { useEffect, useRef } from "react"
+import { IoMdClose } from "react-icons/io"
+
+// Modal Context
+const ModalContext = React.createContext(undefined)
+
+// Main Modal Component
+const Modal = ({
+  open,
+  onClose,
+  children,
+  size = "md",
+  closeOnOverlay = true,
+  closeOnEsc = true,
+  showCloseButton = true,
+}) => {
+  const modalRef = useRef(null)
+  const previousActiveElement = useRef(null)
+
+  // Size classes
+  const sizeClasses = {
+    sm: "max-w-sm",
+    md: "max-w-md",
+    lg: "max-w-lg",
+    xl: "max-w-xl",
+    full: "max-w-full mx-4",
+  }
+
+  // Handle ESC key
+  useEffect(() => {
+    if (!open || !closeOnEsc) return
+
+    const handleEsc = e => {
+      if (e.key === "Escape") {
+        onClose()
+      }
+    }
+
+    document.addEventListener("keydown", handleEsc)
+    return () => document.removeEventListener("keydown", handleEsc)
+  }, [open, closeOnEsc, onClose])
+
+  // Focus management
+  useEffect(() => {
+    if (open) {
+      previousActiveElement.current = document.activeElement
+      modalRef.current?.focus()
+    } else {
+      previousActiveElement.current?.focus()
+    }
+  }, [open])
+
+  // Prevent body scroll when modal is open
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden"
+    } else {
+      document.body.style.overflow = ""
+    }
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [open])
+
+  // Focus trap
+  const handleTabKey = e => {
+    if (e.key !== "Tab") return
+
+    const focusableElements = modalRef.current?.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    )
+
+    if (!focusableElements || focusableElements.length === 0) return
+
+    const firstElement = focusableElements[0]
+    const lastElement = focusableElements[focusableElements.length - 1]
+
+    if (e.shiftKey) {
+      if (document.activeElement === firstElement) {
+        lastElement.focus()
+        e.preventDefault()
+      }
+    } else {
+      if (document.activeElement === lastElement) {
+        firstElement.focus()
+        e.preventDefault()
+      }
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <ModalContext.Provider value={{ onClose }}>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-fadeIn"
+        role="modal"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+      >
+        {/* Overlay */}
+        <div
+          className="fixed inset-0 bg-black/50 animate-fadeIn"
+          onClick={closeOnOverlay ? onClose : undefined}
+          aria-hidden="true"
+        />
+
+        {/* Modal */}
+        <div
+          ref={modalRef}
+          tabIndex={-1}
+          onKeyDown={handleTabKey}
+          className={`relative bg-white rounded-lg shadow-xl w-full ${sizeClasses[size]} animate-scaleIn transform transition-all`}
+        >
+          {showCloseButton && (
+            <button
+              onClick={onClose}
+              className="absolute right-4 top-4 p-1 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Close modal"
+            >
+              <IoMdClose className="w-5 h-5 text-red-500" />
+            </button>
+          )}
+          {children}
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes fadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes scaleIn {
+          from {
+            opacity: 0;
+            transform: scale(0.95);
+          }
+          to {
+            opacity: 1;
+            transform: scale(1);
+          }
+        }
+        .animate-fadeIn {
+          animation: fadeIn 0.2s ease-out;
+        }
+        .animate-scaleIn {
+          animation: scaleIn 0.2s ease-out;
+        }
+      `}</style>
+    </ModalContext.Provider>
+  )
+}
+
+// Modal Header
+const ModalHeader = ({ children, className = "" }) => {
+  return (
+    <div className={`px-6 py-4 border-b border-gray-200 ${className}`}>
+      <h2 id="modal-title" className="text-xl font-semibold text-gray-900">
+        {children}
+      </h2>
+    </div>
+  )
+}
+
+// Modal Body
+const ModalBody = ({ children, className = "" }) => {
+  return <div className={`px-6 py-4 ${className}`}>{children}</div>
+}
+
+// Modal Footer
+const ModalFooter = ({ children, className = "" }) => {
+  return (
+    <div
+      className={`px-6 py-4 border-t border-gray-200 flex items-center justify-end gap-3 ${className}`}
+    >
+      {children}
+    </div>
+  )
+}
+
+// Attach compound components
+Modal.Header = ModalHeader
+Modal.Body = ModalBody
+Modal.Footer = ModalFooter
+
+// Demo Component
+const ModalDemo = () => {
+  const [previewOpen, setPreviewOpen] = React.useState(false)
+
+  return (
+    <div className="bg-white p-8">
+      <div className="mx-auto flex justify-center">
+        {/* Preview Modal Trigger */}
+        <button
+          onClick={() => setPreviewOpen(true)}
+          className="py-3 px-5 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg shadow-sm hover:shadow-md transition-shadow border border-gray-200"
+        >
+          <p className="font-semibold text-white">Preview Modal</p>
+        </button>
+
+        {/* Preview Modal */}
+        <Modal
+          open={previewOpen}
+          onClose={() => setPreviewOpen(false)}
+          size="lg"
+        >
+          <Modal.Header>Image Preview</Modal.Header>
+          <Modal.Body className="p-0">
+            <div className="aspect-video bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white text-2xl font-bold">
+              Preview Content
+            </div>
+            <div className="p-6">
+              <h3 className="font-semibold text-gray-900 mb-2">
+                Beautiful Gradient
+              </h3>
+              <p className="text-gray-600 text-sm">
+                This is an example of a content preview modal. You can display
+                images, videos, or any other content here.
+              </p>
+            </div>
+          </Modal.Body>
+          <Modal.Footer>
+            <button
+              onClick={() => setPreviewOpen(false)}
+              className="px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
+            >
+              Close
+            </button>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    </div>
+  )
+}
+
+export default ModalDemo
+export { Modal }

--- a/components/modal/react/modal/README.md
+++ b/components/modal/react/modal/README.md
@@ -1,0 +1,290 @@
+# Accessible Modal Component
+
+A reusable modal component for displaying forms, confirmation boxes, and alerts. Should include accessibility features, animations, and flexible content placement.
+
+## Features
+
+- **Full Accessibility (WCAG Compliant)**
+  - Focus trap with keyboard navigation
+  - Automatic focus management
+  - ESC key to close
+  - Proper ARIA attributes
+  - Screen reader support
+
+- **Smooth Animations**
+  - Fade-in overlay
+  - Scale-in modal entrance
+  - CSS-based for optimal performance
+
+- **Flexible**
+  - Compound component pattern (Header, Body, Footer)
+  - Multiple size variants
+  - Customizable behaviors
+
+- **Responsive Design**
+  - Mobile-friendly
+  - Prevents body scroll when open
+  - Adaptive sizing
+
+- **Use Cases**
+  - Confirmation modals
+  - Form popups (login, create, edit)
+  - Alert notifications
+  - Content/image previews
+
+## Installation
+
+No external dependencies required beyond React and Tailwind CSS.
+
+1. Copy the component files to your project
+2. Ensure Tailwind CSS is configured in your project
+3. Import and use the component
+
+## Usage
+
+### Basic Example
+
+```jsx
+import { useState } from "react"
+import Modal from "./components/Modal"
+
+function App() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open Modal</button>
+
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <Modal.Header>Modal Title</Modal.Header>
+        <Modal.Body>
+          <p>This is the modal content.</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <button onClick={() => setOpen(false)}>Close</button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  )
+}
+```
+
+### Confirmation Modal
+
+```jsx
+<Modal open={confirmOpen} onClose={() => setConfirmOpen(false)} size="sm">
+  <Modal.Header>Delete Item?</Modal.Header>
+  <Modal.Body>
+    <p>
+      Are you sure you want to delete this item? This action cannot be undone.
+    </p>
+  </Modal.Body>
+  <Modal.Footer>
+    <button onClick={() => setConfirmOpen(false)}>Cancel</button>
+    <button onClick={handleDelete}>Delete</button>
+  </Modal.Footer>
+</Modal>
+```
+
+### Form Modal
+
+```jsx
+<Modal open={formOpen} onClose={() => setFormOpen(false)} size="md">
+  <Modal.Header>Create Account</Modal.Header>
+  <Modal.Body>
+    <div className="space-y-4">
+      <div>
+        <label htmlFor="name">Name</label>
+        <input
+          type="text"
+          id="name"
+          value={formData.name}
+          onChange={e => setFormData({ ...formData, name: e.target.value })}
+        />
+      </div>
+      <div>
+        <label htmlFor="email">Email</label>
+        <input
+          type="email"
+          id="email"
+          value={formData.email}
+          onChange={e => setFormData({ ...formData, email: e.target.value })}
+        />
+      </div>
+    </div>
+  </Modal.Body>
+  <Modal.Footer>
+    <button onClick={() => setFormOpen(false)}>Cancel</button>
+    <button onClick={handleSubmit}>Create Account</button>
+  </Modal.Footer>
+</Modal>
+```
+
+### Alert Modal
+
+```jsx
+<Modal open={alertOpen} onClose={() => setAlertOpen(false)} size="sm">
+  <Modal.Header>Success!</Modal.Header>
+  <Modal.Body>
+    <p>Your changes have been saved successfully.</p>
+  </Modal.Body>
+  <Modal.Footer>
+    <button onClick={() => setAlertOpen(false)}>OK</button>
+  </Modal.Footer>
+</Modal>
+```
+
+### Without Close Button
+
+```jsx
+<Modal
+  open={open}
+  onClose={() => setOpen(false)}
+  showCloseButton={false}
+  closeOnOverlay={false}
+  closeOnEsc={false}
+>
+  <Modal.Header>Important Message</Modal.Header>
+  <Modal.Body>
+    <p>This modal requires explicit action.</p>
+  </Modal.Body>
+  <Modal.Footer>
+    <button onClick={handleAction}>Take Action</button>
+  </Modal.Footer>
+</Modal>
+```
+
+## Props Documentation
+
+### Modal Props
+
+| Prop              | Type                                     | Required | Default | Description                                                      |
+| ----------------- | ---------------------------------------- | -------- | ------- | ---------------------------------------------------------------- |
+| `open`            | `boolean`                                | ✅       | -       | Controls the visibility of the modal                             |
+| `onClose`         | `() => void`                             | ✅       | -       | Callback function triggered when the modal should close          |
+| `children`        | `React.ReactNode`                        | ✅       | -       | Modal content (typically Modal.Header, Modal.Body, Modal.Footer) |
+| `size`            | `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | ❌       | `'md'`  | Sets the maximum width of the modal                              |
+| `closeOnOverlay`  | `boolean`                                | ❌       | `true`  | Whether clicking the overlay/backdrop closes the modal           |
+| `closeOnEsc`      | `boolean`                                | ❌       | `true`  | Whether pressing the ESC key closes the modal                    |
+| `showCloseButton` | `boolean`                                | ❌       | `true`  | Whether to display the X close button in the top-right corner    |
+
+### Size Options
+
+- `sm` - max-width: 24rem (384px)
+- `md` - max-width: 28rem (448px)
+- `lg` - max-width: 32rem (512px)
+- `xl` - max-width: 36rem (576px)
+- `full` - Full width with margin
+
+### Modal.Header Props
+
+| Prop        | Type              | Required | Default | Description                                |
+| ----------- | ----------------- | -------- | ------- | ------------------------------------------ |
+| `children`  | `React.ReactNode` | ✅       | -       | Header content (typically the modal title) |
+| `className` | `string`          | ❌       | `''`    | Additional CSS classes to apply            |
+
+### Modal.Body Props
+
+| Prop        | Type              | Required | Default | Description                     |
+| ----------- | ----------------- | -------- | ------- | ------------------------------- |
+| `children`  | `React.ReactNode` | ✅       | -       | Main modal content              |
+| `className` | `string`          | ❌       | `''`    | Additional CSS classes to apply |
+
+### Modal.Footer Props
+
+| Prop        | Type              | Required | Default | Description                               |
+| ----------- | ----------------- | -------- | ------- | ----------------------------------------- |
+| `children`  | `React.ReactNode` | ✅       | -       | Footer content (typically action buttons) |
+| `className` | `string`          | ❌       | `''`    | Additional CSS classes to apply           |
+
+## Customization Guide
+
+### Styling
+
+The component uses Tailwind CSS classes. You can customize the appearance by:
+
+1. **Modifying default classes** in the component file
+2. **Passing custom classes** via the `className` prop on sub-components
+3. **Overriding Tailwind theme** in your `tailwind.config.js`
+
+### Custom Overlay Color
+
+```jsx
+// Edit the overlay div in the Modal component
+<div
+  className="fixed inset-0 bg-blue-900/50 animate-fadeIn" // Change from bg-black/50
+  onClick={closeOnOverlay ? onClose : undefined}
+  aria-hidden="true"
+/>
+```
+
+### Custom Animation Duration
+
+```jsx
+// Edit the style tag in the Modal component
+<style>{`
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  @keyframes scaleIn {
+    from {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  .animate-fadeIn {
+    animation: fadeIn 0.3s ease-out; /* Change from 0.2s */
+  }
+  .animate-scaleIn {
+    animation: scaleIn 0.3s ease-out; /* Change from 0.2s */
+  }
+`}</style>
+```
+
+### Custom Header Styling
+
+```jsx
+<Modal.Header className="bg-blue-600 text-white">
+  Custom Styled Header
+</Modal.Header>
+```
+
+### Custom Footer Layout
+
+```jsx
+<Modal.Footer className="justify-between">
+  {" "}
+  {/* Instead of justify-end */}
+  <button>Secondary Action</button>
+  <div className="flex gap-2">
+    <button>Cancel</button>
+    <button>Confirm</button>
+  </div>
+</Modal.Footer>
+```
+
+### Adding New Size Options
+
+Edit the `sizeClasses` object in the Modal component:
+
+```jsx
+const sizeClasses = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+  "2xl": "max-w-2xl", // Add new size
+  full: "max-w-full mx-4",
+}
+```
+
+## Dependencies
+
+- **React** (v16.8+) - For hooks support
+- **Tailwind CSS** (v3.0+) - For styling
+- **react-icons** - For the close icon (X)

--- a/components/modal/react/modal/component.json
+++ b/components/modal/react/modal/component.json
@@ -1,0 +1,113 @@
+{
+  "name": "modal",
+  "category": "overlay",
+  "framework": "react",
+  "tags": ["modal", "dialog", "confirm", "overlay", "popup"],
+  "author": "Mahmud1087",
+  "license": "MIT",
+  "version": "1.0.0",
+  "preview": "A reusable modal/dialog component for displaying forms, confirmation boxes, and alerts. Should include accessibility features, animations, and flexible content placement.",
+  "demoUrl": "",
+  "dependencies": ["react", "tailwindcss"],
+  "props": [
+    {
+      "name": "open",
+      "type": "boolean",
+      "required": true,
+      "description": "Controls the visibility of the modal"
+    },
+    {
+      "name": "onClose",
+      "type": "() => void",
+      "required": true,
+      "description": "Callback function triggered when the modal should close"
+    },
+    {
+      "name": "children",
+      "type": "React.ReactNode",
+      "required": true,
+      "description": "Modal content - typically Modal.Header, Modal.Body, and Modal.Footer components"
+    },
+    {
+      "name": "size",
+      "type": "'sm' | 'md' | 'lg' | 'xl' | 'full'",
+      "required": false,
+      "default": "md",
+      "description": "Sets the maximum width of the modal"
+    },
+    {
+      "name": "closeOnOverlay",
+      "type": "boolean",
+      "required": false,
+      "default": true,
+      "description": "Whether clicking the overlay/backdrop closes the modal"
+    },
+    {
+      "name": "closeOnEsc",
+      "type": "boolean",
+      "required": false,
+      "default": true,
+      "description": "Whether pressing the ESC key closes the modal"
+    },
+    {
+      "name": "showCloseButton",
+      "type": "boolean",
+      "required": false,
+      "default": true,
+      "description": "Whether to display the X close button in the top-right corner"
+    }
+  ],
+  "subComponents": [
+    {
+      "name": "Modal.Header",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": true,
+          "description": "Header content - typically the modal title"
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false,
+          "description": "Additional CSS classes to apply to the header"
+        }
+      ]
+    },
+    {
+      "name": "Modal.Body",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": true,
+          "description": "Main modal content"
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false,
+          "description": "Additional CSS classes to apply to the body"
+        }
+      ]
+    },
+    {
+      "name": "Modal.Footer",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": true,
+          "description": "Footer content - typically action buttons"
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false,
+          "description": "Additional CSS classes to apply to the footer"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Pull Request

## Description
A reusable modal component for displaying forms, confirmation boxes, and alerts.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New component (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Component Details (if applicable)
- **Component Name**:  Modal
- **Category**: Overlay
- **Framework**: ReactJS

## Checklist
- [x] My code follows the code style of this project
- [x] I have included a screenshot or demo of the component
- [x] I have added/updated appropriate documentation (README.md)
- [x] I have verified the component metadata follows the schema
- [x] All validation checks pass (`pnpm validate`)
- [x] The component includes proper MIT license attribution
- [ ] I have tested the component in different screen sizes (if applicable)

## Screenshots
<img width="1169" height="365" alt="Screenshot 2025-10-18 161528" src="https://github.com/user-attachments/assets/031ecebc-5c87-4dff-ada3-bf33ca8affd0" />
<img width="1366" height="645" alt="Screenshot 2025-10-18 161545" src="https://github.com/user-attachments/assets/5858e817-d695-413f-81ba-9ffeb02d0f87" />

## Additional Notes
Closes #161 
